### PR TITLE
Hacking checkout/npm-install into deploy-job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,10 @@ jobs:
       - image: circleci/node:8.12
     working_directory: /tmp/my-project
     steps:
+      - checkout
+      - run: 
+          name: Install NPM Dependencies
+          command: npm install
       - run:
           name: Deploy Master to Firebase
           command: ./node_modules/.bin/firebase deploy --token=$FIREBASE_HOSTING_TOKEN


### PR DESCRIPTION
For the time being... Ideally this should be done in the build-job and stored in a cache (or artifact storage)